### PR TITLE
Rename project to oracle-mcp-server and update related configurations…

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   REGISTRY: docker.io
-  IMAGE_NAME: dmeppiel/mcp-db-context
+  IMAGE_NAME: dmeppiel/oracle-mcp-server
 
 jobs:
   publish:

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ In VSCode Insiders, go to your user or workspace `settings.json` file and add th
         }
       ],
        "servers": {
-           "db-context": {
+           "oracle": {
                "command": "docker",
                "args": [
                    "run",
@@ -95,7 +95,7 @@ In VSCode Insiders, go to your user or workspace `settings.json` file and add th
                    "CACHE_DIR",
                    "-e",
                    "THICK_MODE",
-                   "dmeppiel/mcp-db-context"
+                   "dmeppiel/oracle-mcp-server"
                ],
                "env": {
                   "ORACLE_CONNECTION_STRING":"<db-username>/${input:db-password}@<host>:1521/<service-name>",
@@ -134,8 +134,8 @@ In VSCode Insiders, go to your user or workspace `settings.json` file and add th
    3. **Project Setup**
       ```bash
       # Clone repository
-      git clone https://github.com/yourusername/mcp-db-context.git
-      cd mcp-db-context
+      git clone https://github.com/yourusername/oracle-mcp-server.git
+      cd oracle-mcp-server
 
       # Create and activate virtual environment
       uv venv
@@ -162,11 +162,11 @@ In VSCode Insiders, go to your user or workspace `settings.json` file and add th
             }
          ],
          "servers": {
-            "db-context": {
+            "oracle": {
                   "command": "/path/to/your/.local/bin/uv",
                   "args": [
                      "--directory",
-                     "/path/to/your/mcp-db-context",
+                     "/path/to/your/oracle-mcp-server",
                      "run",
                      "main.py"
                   ],
@@ -180,7 +180,7 @@ In VSCode Insiders, go to your user or workspace `settings.json` file and add th
          }
       }
       ```
-   - Replace the paths with your actual uv binary path and mcp-db-context directory path
+   - Replace the paths with your actual uv binary path and oracle-mcp-server directory path
 
 For both options:
 - Replace the `ORACLE_CONNECTION_STRING` with your actual database connection string

--- a/main.py
+++ b/main.py
@@ -49,7 +49,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[DatabaseContext]:
         print("Database connections closed", file=sys.stderr)
 
 # Initialize FastMCP server
-mcp = FastMCP("db-context", lifespan=app_lifespan)
+mcp = FastMCP("oracle", lifespan=app_lifespan)
 print("FastMCP server initialized", file=sys.stderr)
 
 @mcp.tool()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
-name = "mcp-db-context"
-version = "0.1.0"
+name = "oracle-mcp-server"
+version = "0.1.3"
 description = "MCP server for Oracle database schema context retrieval"
 requires-python = ">=3.12"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -222,8 +222,8 @@ wheels = [
 ]
 
 [[package]]
-name = "mcp-db-context"
-version = "0.1.0"
+name = "oracle-mcp-server"
+version = "0.1.3"
 source = { virtual = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
This pull request includes changes to rename the project from `mcp-db-context` to `oracle-mcp-server` across various files and configurations. The most important changes include updates to the Docker image name, modifications in the `README.md` file, and adjustments in the project configuration files.