### PR TITLE
Fix thin mode initialization

### DIFF
--- a/db_context/database.py
+++ b/db_context/database.py
@@ -38,7 +38,7 @@ class DatabaseConnector:
                             getmode=oracledb.POOL_GETMODE_WAIT
                         )
                     else:
-                        self._pool = await oracledb.create_pool_async(
+                        self._pool = oracledb.create_pool_async(
                             self.connection_string,
                             min=2,
                             max=10,


### PR DESCRIPTION
This pull request includes a minor change to the `initialize_pool` method in `db_context/database.py`. The `await` keyword was removed from the call to `oracledb.create_pool_async`, because the method does not require asynchronous execution.

Fixes #13 